### PR TITLE
Add compute and print error v2(optimised on gpu) and v3(working on gp…

### DIFF
--- a/src/Pattern4GPU.axl
+++ b/src/Pattern4GPU.axl
@@ -338,6 +338,8 @@
     <enumvalue name="ori" genvalue="CPEV_ori" />
     <enumvalue name="arcgpu_v0" genvalue="CPEV_arcgpu_v0" />
     <enumvalue name="arcgpu_v1" genvalue="CPEV_arcgpu_v1" />
+    <enumvalue name="arcgpu_v2" genvalue="CPEV_arcgpu_v2" />
+    <enumvalue name="arcgpu_v3" genvalue="CPEV_arcgpu_v3" />
   </enumeration>
 
   <!-- - - - - init-menv-var-version - - - - -->

--- a/src/Pattern4GPUModule.cc
+++ b/src/Pattern4GPUModule.cc
@@ -40,7 +40,8 @@ Pattern4GPUModule(const ModuleBuildInfo& mbi)
   m_compyy(MaterialVariableBuildInfo(
         m_mesh_material_mng, "Compyy", IVariable::PTemporary | IVariable::PExecutionDepend)),
   m_tmp1(VariableBuildInfo(mesh(), "Tmp1", IVariable::PTemporary | IVariable::PExecutionDepend)),
-  m_kokkos_wrapper(nullptr)
+  m_kokkos_wrapper(nullptr),
+  min_cid_on_err(MemoryAllocationOptions(platform::getAcceleratorHostMemoryAllocator(),eMemoryLocationHint::MainlyHost),1) 
 {
 }
 

--- a/src/Pattern4GPUModule.h
+++ b/src/Pattern4GPUModule.h
@@ -101,6 +101,8 @@ class Pattern4GPUModule
   void _computeAndPrintError_Vori();
   void _computeAndPrintError_Varcgpu_v0();
   void _computeAndPrintError_Varcgpu_v1();
+  void _computeAndPrintError_Varcgpu_v2();
+  void _computeAndPrintError_Varcgpu_v3();
 
   void _testCell2Cell();
   void _testNode2Node();
@@ -165,6 +167,7 @@ class Pattern4GPUModule
 
   // TEST, pour amortir cout des allocs pour GPU
   BufAddrMng* m_buf_addr_mng=nullptr;
+  UniqueArray<Integer> min_cid_on_err;
 };
 
 #endif

--- a/src/Pattern4GPUOptions.h
+++ b/src/Pattern4GPUOptions.h
@@ -85,7 +85,9 @@ enum eComputeCqsVectorVersion {
 enum eComputeAndPrintError {
   CPEV_ori = 0, //! Version CPU d'origine
   CPEV_arcgpu_v0, //! Implémentation API GPU Arcane version 0 (sans gestion d'erreur)
-  CPEV_arcgpu_v1  //! Implémentation API GPU Arcane version 1
+  CPEV_arcgpu_v1,  //! Implémentation API GPU Arcane version 1
+  CPEV_arcgpu_v2,  //! Implémentation API GPU Arcane version 2
+  CPEV_arcgpu_v3  //! Implémentation API GPU Arcane version 3
 };
 
 /*! \brief Définit les implémentations de InitMEnvVar


### PR DESCRIPTION
Ajout de versions 2 et 3 pour la gestion des erreurs, basées sur une variable en mémoire managée.

Version 2: Renvoi du plus petit ID de maille sur GPU, renvoi d'un ID de maille en erreur quelconque autrement
Version 3: Renvoi d'un ID de maille en erreur quelconque sur GPU et en multihread.